### PR TITLE
chore: upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'Indicates if extracted values should be masked in GitHub action logs'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
Node.js 20 is deprecated on GitHub Actions runners and will be removed on September 16, 2026. Actions will be forced to run with Node.js 24 by default starting June 2, 2026.